### PR TITLE
Add link to Spring Content in the Related Modules section 

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@ Core Spring concepts underpinning every Spring Data project.
 
 * [Spring Data JDBC Extensions](http://projects.spring.io/spring-data-jdbc-ext) - Provides extensions to the JDBC support provided in the Spring Framework.
 * [Spring for Apache Hadoop](http://projects.spring.io/spring-hadoop) - Simplifies Apache Hadoop by providing a unified configuration model and easy to use APIs for using HDFS, MapReduce, Pig, and Hive.
+* [Spring Content](https://paulcwarren.github.io/spring-content/) - Associate content with your Spring Data Entities and store it in a number of different stores including the File-system, S3, Database or Mongo's GridFS.
 
 <a name="release-train"></a>
 


### PR DESCRIPTION
Hi Team,

Luke Woydziak and myself spoke with Brian Dassault and Oli a while back about adding a link to our Spring Content project under the 'Related Modules' section.

There were a number of actions we had to do first, the most important of which was to delineate the Spring Content API from Spring Data's API by moving off of the term 'Repository' and onto the term 'Store'.  This has been done everywhere throughout the docs and the code.  A developer now uses a 'Repository' to store his structured data and a 'Store' to store his unstructured data.

@lwoydziak